### PR TITLE
Update setup.php fixing 'infinite updating'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Dans le cas d'envoi par courriel, l'adresse utilisée pour l'expéditeur est cel
 
 ## EN
 
-This plugin unable the export of saved searches's results in CSV files with a cron task.
-For each configured export, you can define an email adress to which the file will be sent, and an interval between each export.
+This plugin allows for the export of saved searches's results in CSV files with a cron task.
+For each configured export, you can define an email address to which the file will be sent, and an interval between each export.
 
 You can access the export configuration screen from the **Tools** menu.
-The mails will be sent using the adress defined in the mail notification setting, field "Sender email".
+The mails will be sent using the address defined in the mail notification setting, field "Sender email".
 

--- a/setup.php
+++ b/setup.php
@@ -26,7 +26,7 @@
  --------------------------------------------------------------------------
  */
 
-define('PLUGIN_AUTOEXPORTSEARCH_VERSION', '2.1.3');
+define('PLUGIN_AUTOEXPORTSEARCH_VERSION', '2.1.4');
 
 if (!defined("PLUGIN_AUTOEXPORTSEARCH_DIR")) {
     define("PLUGIN_AUTOEXPORTSEARCH_DIR", Plugin::getPhpDir("autoexportsearches"));


### PR DESCRIPTION
With 2.1.4's release the setup.php file wasn't updated, meaning GLPI doesn't register the update as successful and keeps prompting for the plugin to be updated.

Also minor changes to the EN section of the Readme.